### PR TITLE
[DynamoDB] add sort key to tasks and events tables

### DIFF
--- a/dynamodb/mock/mock_dynamodb.go
+++ b/dynamodb/mock/mock_dynamodb.go
@@ -74,7 +74,7 @@ func (mdb *MockDynamoDBClient) AddTask(ctx context.Context, req *dynamodb.AddTas
 	if mdb.TasksTable == nil {
 		mdb.TasksTable = make(map[string]dynamodb.Task)
 	}
-	mdb.TasksTable[req.Task.ID] = req.Task
+	mdb.TasksTable[req.Task.TaskID] = req.Task
 	return &dynamodb.AddTaskResp{}, nil
 }
 
@@ -85,7 +85,10 @@ func (mdb *MockDynamoDBClient) GetTask(ctx context.Context, req *dynamodb.GetTas
 	if mdb.TasksTable == nil {
 		return nil, errors.New("tasksTable does not exist")
 	}
-	task := mdb.TasksTable[req.ID]
+	task := mdb.TasksTable[req.TaskID]
+	if task.UserID != req.UserID {
+		return nil, errors.New("unauthorized")
+	}
 	return &dynamodb.GetTaskResp{
 		Task: &task,
 	}, nil

--- a/dynamodb/table-definitions/events.json
+++ b/dynamodb/table-definitions/events.json
@@ -2,7 +2,7 @@
   "TableName": "todo-events",
   "KeySchema": [
     { "AttributeName": "user_id", "KeyType": "HASH" },
-    { "AttributeName": "event_id", "KeyTpe": "RANGE" }
+    { "AttributeName": "event_id", "KeyType": "RANGE" }
   ],
   "AttributeDefinitions": [
     { "AttributeName": "user_id", "AttributeType": "S" },

--- a/dynamodb/table-definitions/events.json
+++ b/dynamodb/table-definitions/events.json
@@ -1,13 +1,15 @@
 {
-    "TableName": "todo-events",
-    "KeySchema": [
-      { "AttributeName": "id", "KeyType": "HASH" }
-    ],
-    "AttributeDefinitions": [
-      { "AttributeName": "id", "AttributeType": "S" }
-    ],
-    "ProvisionedThroughput": {
-      "ReadCapacityUnits": 5,
-      "WriteCapacityUnits": 5
-    }
+  "TableName": "todo-events",
+  "KeySchema": [
+    { "AttributeName": "user_id", "KeyType": "HASH" },
+    { "AttributeName": "event_id", "KeyTpe": "RANGE" }
+  ],
+  "AttributeDefinitions": [
+    { "AttributeName": "user_id", "AttributeType": "S" },
+    { "AttributeName": "event_id", "AttributeType": "S" }
+  ],
+  "ProvisionedThroughput": {
+    "ReadCapacityUnits": 5,
+    "WriteCapacityUnits": 5
+  }
 }

--- a/dynamodb/table-definitions/tasks.json
+++ b/dynamodb/table-definitions/tasks.json
@@ -1,10 +1,12 @@
 {
     "TableName": "todo-tasks",
     "KeySchema": [
-      { "AttributeName": "id", "KeyType": "HASH" }
+      { "AttributeName": "user_id", "KeyType": "HASH" },
+      { "AttributeName": "task_id", "KeyTpe": "RANGE" }
     ],
     "AttributeDefinitions": [
-      { "AttributeName": "id", "AttributeType": "S" }
+      { "AttributeName": "user_id", "AttributeType": "S" },
+      { "AttributeName": "task_id", "AttributeType": "S" }
     ],
     "ProvisionedThroughput": {
       "ReadCapacityUnits": 5,

--- a/dynamodb/table-definitions/tasks.json
+++ b/dynamodb/table-definitions/tasks.json
@@ -2,7 +2,7 @@
     "TableName": "todo-tasks",
     "KeySchema": [
       { "AttributeName": "user_id", "KeyType": "HASH" },
-      { "AttributeName": "task_id", "KeyTpe": "RANGE" }
+      { "AttributeName": "task_id", "KeyType": "RANGE" }
     ],
     "AttributeDefinitions": [
       { "AttributeName": "user_id", "AttributeType": "S" },

--- a/dynamodb/tasks.go
+++ b/dynamodb/tasks.go
@@ -17,8 +17,8 @@ type RecurringRule struct {
 }
 
 type Task struct {
-	ID            string         `dynamodbav:"id"`
 	UserID        string         `dynamodbav:"user_id"`
+	TaskID        string         `dynamodbav:"task_id"`
 	Title         string         `dynamodbav:"title"`
 	Description   string         `dynamodbav:"description"`
 	Status        string         `dynamodbav:"status"`
@@ -49,7 +49,8 @@ func (ddb *DynamoDBClient) AddTask(ctx context.Context, req *AddTaskReq) (*AddTa
 }
 
 type GetTaskReq struct {
-	ID string `dynamodbav:"id"`
+	UserID string
+	TaskID string
 }
 type GetTaskResp struct {
 	Task *Task
@@ -59,7 +60,8 @@ func (ddb *DynamoDBClient) GetTask(ctx context.Context, req *GetTaskReq) (*GetTa
 	getItemResp, err := ddb.client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: &ddb.tasksTableName,
 		Key: map[string]types.AttributeValue{
-			"id": &types.AttributeValueMemberS{Value: req.ID},
+			"user_id": &types.AttributeValueMemberS{Value: req.UserID},
+			"task_id": &types.AttributeValueMemberS{Value: req.TaskID},
 		},
 	})
 	if err != nil {

--- a/service/tasks_test.go
+++ b/service/tasks_test.go
@@ -197,8 +197,8 @@ func Test_todoServer_GetTask(t *testing.T) {
 				ddb: &ddbMock.MockDynamoDBClient{
 					TasksTable: map[string]dynamodb.Task{
 						"task_id": {
-							ID:     "task_id",
 							UserID: common.TEST_USER_1_ID,
+							TaskID: "task_id",
 							Title:  "task title",
 							Status: proto.Status_INCOMPLETE.String(),
 						},
@@ -227,8 +227,8 @@ func Test_todoServer_GetTask(t *testing.T) {
 				ddb: &ddbMock.MockDynamoDBClient{
 					TasksTable: map[string]dynamodb.Task{
 						"task_id": {
-							ID:     "task_id",
 							UserID: common.TEST_USER_1_ID,
+							TaskID: "task_id",
 							Title:  "task title",
 							Status: proto.Status_INCOMPLETE.String(),
 						},
@@ -251,8 +251,8 @@ func Test_todoServer_GetTask(t *testing.T) {
 				ddb: &ddbMock.MockDynamoDBClient{
 					TasksTable: map[string]dynamodb.Task{
 						"task_id": {
-							ID:     "task_id",
 							UserID: "wrong_user_id",
+							TaskID: "task_id",
 							Title:  "task title",
 							Status: proto.Status_INCOMPLETE.String(),
 						},


### PR DESCRIPTION
## Summary
I've decided to use the user's id as the partition key for the tasks table (and the events table in case I implement that). I believe this makes dynamodb more efficient when users are all looking for all of their tasks.